### PR TITLE
Fix SHA-256 signing issues

### DIFF
--- a/firefox-win/plugin-class.h
+++ b/firefox-win/plugin-class.h
@@ -64,6 +64,8 @@ BOOL Unicode16ToAnsi(WCHAR *in_Src, CHAR *out_Dst, INT in_MaxLen);
 
 char* byteToChar(BYTE* signature, int length );
 
+void reverseBytes(BYTE* signature, int signatureLength);
+
 bool selectCertificate(PluginInstance *obj, PCCERT_CONTEXT *certContext);
 
 void handleError(char* methodName, PluginInstance *obj);


### PR DESCRIPTION
Here is one possible fix for SHA-256 signing problems. Removes the 20 byte limit for hash buffer, removes the conversion from hex string to bytes and reverses the signature bytes before output (verification will thus work with OpenSSL)
