### PR TITLE
Various random fixes

### DIFF
--- a/common/cert_dialog_win.h
+++ b/common/cert_dialog_win.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __CERT_DIAOLG_WIN_H__
-#define	__CERT_DIAOLG_WIN_H__
+#ifndef ESTEID_CERT_DIAOLG_WIN_H
+#define	ESTEID_CERT_DIAOLG_WIN_H
 
 #include <windows.h>
 #include <cryptuiapi.h>

--- a/common/dialogs-cocoa.h
+++ b/common/dialogs-cocoa.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PIN_PROMPT_COCOA_H__
-#define __PIN_PROMPT_COCOA_H__
+#ifndef ESTEID_PIN_PROMPT_COCOA_H
+#define ESTEID_PIN_PROMPT_COCOA_H
 
 #import <Cocoa/Cocoa.h>
 

--- a/common/dialogs.h
+++ b/common/dialogs.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __DIALOGS_H__
-#define __DIALOGS_H__
+#ifndef ESTEID_DIALOGS_H
+#define ESTEID_DIALOGS_H
 
 #ifndef _WIN32
 #define IDOK 0

--- a/common/esteid_certinfo.c
+++ b/common/esteid_certinfo.c
@@ -396,7 +396,7 @@ int EstEID_loadCertInfoEntries(EstEID_Certs *certs, int index) {
 	EstEID_mapPutNoAlloc(cert, strdup("validFrom"), EstEID_ASN1_TIME_toString(X509_get_notBefore(x509)));
 
 	usage = (ASN1_BIT_STRING *)X509_get_ext_d2i(x509, NID_key_usage, NULL, NULL);
-	if (usage->length > 0) keyUsage = usage->data[0];
+	keyUsage = (usage->length > 0) ? usage->data[0] : 0u;
 	ASN1_BIT_STRING_free(usage);
 
 	if (keyUsage & X509v3_KU_DIGITAL_SIGNATURE) EstEID_mapPut(cert, "usageDigitalSignature", "TRUE");

--- a/common/esteid_certinfo.h
+++ b/common/esteid_certinfo.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_CERTINFO_H__
-#define __ESTEID_CERTINFO_H__
+#ifndef ESTEID_CERTINFO_H
+#define ESTEID_CERTINFO_H
 
 #define CRYPTOKI_COMPAT
 #include "pkcs11.h"

--- a/common/esteid_dialog_common.h
+++ b/common/esteid_dialog_common.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_DIALOG_COMMON_H__
-#define __ESTEID_DIALOG_COMMON_H__
+#ifndef ESTEID_DIALOG_COMMON_H
+#define ESTEID_DIALOG_COMMON_H
 
 char* createDialogTitle(const char* nameAndID);
 

--- a/common/esteid_error.h
+++ b/common/esteid_error.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_ERROR_H__
-#define	__ESTEID_ERROR_H__
+#ifndef ESTEID_ERROR_H
+#define	ESTEID_ERROR_H
 
 #define ESTEID_ERROR_SIZE 1024
 

--- a/common/esteid_json.c
+++ b/common/esteid_json.c
@@ -29,10 +29,15 @@ int isEscapedSymbol(char c) {
 }
 
 char *EstEID_jsonString(const char *src) {
-	int specialSymbolCount = 0;
+	size_t specialSymbolCount = 0u;
 	char *s = (char *)src;
-	while (*s) if (isEscapedSymbol(*(s++))) specialSymbolCount++;
-	char *result = (char*)malloc(strlen(src) + specialSymbolCount + 1);
+	size_t srcLen = 0u;
+	for (; *s; srcLen++) if (isEscapedSymbol(*(s++))) specialSymbolCount++;
+	if (SIZE_MAX - srcLen < specialSymbolCount)
+		return NULL;
+	if (SIZE_MAX - srcLen - specialSymbolCount < 1u)
+		return NULL;
+	char *result = (char*)malloc(srcLen + specialSymbolCount + 1u);
 	if (!result)
 		return NULL;
 	s = (char *)src;
@@ -56,41 +61,59 @@ char *EstEID_mapEntryToJson(struct EstEID_MapEntry entry) {
 	if (!k)
 		return NULL;
 	char *v = EstEID_jsonString(entry.value);
-	if (!v) {
-		free(k);
-		return NULL;
-	}
-	char *result = (char *)malloc(strlen(k) + strlen(v) + 7);
+	if (!v)
+		goto EstEID_mapEntryToJson_cleanup;
+	size_t const kLen = strlen(k);
+	if (SIZE_MAX - kLen < 7u)
+		goto EstEID_mapEntryToJson_cleanup_2;
+	size_t const vLen = strlen(v);
+	if (SIZE_MAX - kLen - 7u < vLen)
+		goto EstEID_mapEntryToJson_cleanup_2;
+	char *result = (char *)malloc(kLen + vLen + 7u);
 	if (result)
 		sprintf(result, "\"%s\": \"%s\"", k, v);
 	free(k);
 	free(v);
 	return result;
+EstEID_mapEntryToJson_cleanup_2:
+	free(v);
+EstEID_mapEntryToJson_cleanup:
+	free(k);
+	return NULL;
 }
 
 char *EstEID_mapToJson(EstEID_Map map) {
-	char *result = (char *)malloc(3);
+	size_t rLen = 3u;
+	char * result = (char *) malloc(rLen);
 	if (!result)
 		return NULL;
 	memcpy(result, "{", 2u);
-	while (map) {
-		char *entry = EstEID_mapEntryToJson(*map);
-		if (!entry)
-			goto EstEID_mapToJson_error_cleanup;
-		char * const newResult = (char *) realloc(result, strlen(result) + strlen(entry) + 4);
-		if (!newResult) {
-			free(entry);
-			goto EstEID_mapToJson_error_cleanup;
+	char * entry;
+	for (; map; map = map->next) {
+		if (map->next) {
+			if (SIZE_MAX - rLen < 2u)
+				goto EstEID_mapToJson_error_cleanup;
+			rLen += 2u;
 		}
+		if (!(entry = EstEID_mapEntryToJson(*map)))
+			goto EstEID_mapToJson_error_cleanup;
+		size_t const eLen = strlen(entry);
+		if (SIZE_MAX - rLen < eLen)
+			goto EstEID_mapToJson_error_cleanup;
+		rLen += eLen;
+		char * const newResult = (char *) realloc(result, rLen);
+		if (!newResult)
+			goto EstEID_mapToJson_error_cleanup;
 		result = newResult;
 		strcat(result, entry);
 		free(entry);
+		entry = NULL;
 		if (map->next) strcat(result, ", ");
-		map = map->next;
 	}
 	strcat(result, "}");
 	return result;
 EstEID_mapToJson_error_cleanup:
+	free(entry);
 	free(result);
 	return NULL;
 }

--- a/common/esteid_json.c
+++ b/common/esteid_json.c
@@ -63,7 +63,13 @@ char *EstEID_mapToJson(EstEID_Map map) {
 	sprintf(result, "{");
 	while (map) {
 		char *entry = EstEID_mapEntryToJson(*map);
-		result = (char *)realloc(result, strlen(result) + strlen(entry) + 4);
+		char * const newResult = (char *) realloc(result, strlen(result) + strlen(entry) + 4);
+		if (!newResult) {
+			free(entry);
+			free(result);
+			return NULL;
+		}
+		result = newResult;
 		strcat(result, entry);
 		free(entry);
 		if (map->next) strcat(result, ", ");

--- a/common/esteid_json.h
+++ b/common/esteid_json.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_JSON_H__
-#define	__ESTEID_JSON_H__
+#ifndef ESTEID_JSON_H
+#define	ESTEID_JSON_H
 
 #include "esteid_map.h"
 

--- a/common/esteid_json_test.c
+++ b/common/esteid_json_test.c
@@ -19,12 +19,18 @@
  *
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include "esteid_json.h"
 
 void assertStringEquals(const char *expected, char *actual) {
+	assert(expected);
+	if (!actual) {
+		fprintf(stderr, "Out of memory!\n");
+		abort();
+	}
 	if (strcmp(expected, actual)) {
 		printf("assertion failed - expected: [%s], actual [%s]\n", expected, actual);
 		free(actual);

--- a/common/esteid_log.h
+++ b/common/esteid_log.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_LOG__
-#define __ESTEID_LOG__
+#ifndef ESTEID_LOG_H
+#define ESTEID_LOG_H
 
 #include "esteid_map.h"
 

--- a/common/esteid_map.h
+++ b/common/esteid_map.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_MAP_H__
-#define	__ESTEID_MAP_H__
+#ifndef ESTEID_MAP_H
+#define	ESTEID_MAP_H
 
 #include <stdio.h>
 

--- a/common/esteid_mime_types.h
+++ b/common/esteid_mime_types.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __MIME_TYPES_H__
-#define __MIME_TYPES_H__
+#ifndef ESTEID_MIME_TYPES_H
+#define ESTEID_MIME_TYPES_H
 
 #define MIME_TYPE         "application/x-digidoc"
 

--- a/common/esteid_sign.c
+++ b/common/esteid_sign.c
@@ -343,7 +343,7 @@ int EstEID_signHash(char **signature, unsigned int *signatureLength, CK_SLOT_ID 
 			// Simple card reader
 			char *pin = pinPromptData.promptFunction(pinPromptData.nativeWindowHandle, name, message, (unsigned)atoi(EstEID_mapGet(cert, "minPinLen")), isPinPad);
 			if (!pin || strlen(pin) == 0) {
-				if (pin) free(pin);
+				free(pin);
 				setUserCancelErrorCodeAndMessage();
 				CLOSE_SESSION_AND_RETURN(FAILURE);
 			}

--- a/common/esteid_sign.h
+++ b/common/esteid_sign.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_SIGN__
-#define __ESTEID_SIGN__
+#ifndef ESTEID_SIGN_H
+#define ESTEID_SIGN_H
 
 #include "esteid_certinfo.h"
 

--- a/common/esteid_time.h
+++ b/common/esteid_time.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_TIME_H__
-#define __ESTEID_TIME_H__
+#ifndef ESTEID_TIME_H
+#define ESTEID_TIME_H
 
 #include <time.h>
 #ifndef _WIN32

--- a/common/esteid_timer.h
+++ b/common/esteid_timer.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __ESTEID_TIMER_H__
-#define	__ESTEID_TIMER_H__
+#ifndef ESTEID_TIMER_H
+#define	ESTEID_TIMER_H
 
 #include "esteid_time.h"
 

--- a/common/l10n.h
+++ b/common/l10n.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __L10N_H__
-#define	__L10N_H__
+#ifndef ESTEID_L10N_H
+#define	ESTEID_L10N_H
 
 const char *l10n(const char *en);
 

--- a/common/labels.h
+++ b/common/labels.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __LABELS_H__
-#define	__LABELS_H__
+#ifndef ESTEID_LABELS_H
+#define	ESTEID_LABELS_H
 
 
 label labels[] = {

--- a/common/pkcs11_errors.h
+++ b/common/pkcs11_errors.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PKCS11_ERRORS_H__
-#define __PKCS11_ERRORS_H__
+#ifndef ESTEID_PKCS11_ERRORS_H
+#define ESTEID_PKCS11_ERRORS_H
 
 #define CRYPTOKI_COMPAT
 #include "pkcs11.h"

--- a/common/version.h
+++ b/common/version.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __VERSION_H__
-#define __VERSION_H__
+#ifndef ESTEID_VERSION_H
+#define ESTEID_VERSION_H
 
 #ifdef WIN64
 #define ESTEID_PLUGIN_VERSION "3.11.0 64bit"

--- a/firefox-win/cert-class.h
+++ b/firefox-win/cert-class.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __CERT_CLASS_H__
-#define	__CERT_CLASS_H__
+#ifndef ESTEID_CERT_CLASS_H
+#define	ESTEID_CERT_CLASS_H
 
 #include "plugin.h"
 #include "esteid_map.h"

--- a/firefox-win/certselection-win.h
+++ b/firefox-win/certselection-win.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __CERTSELECTION_WIN_H__
-#define __CERTSELECTION_WIN_H__
+#ifndef ESTEID_CERTSELECTION_WIN_H
+#define ESTEID_CERTSELECTION_WIN_H
 
 #include <windows.h>
 #include <windowsx.h>

--- a/firefox-win/dialogs-win.h
+++ b/firefox-win/dialogs-win.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __DIALOGS_WIN_H__
-#define __DIALOGS_WIN_H__
+#ifndef ESTEID_DIALOGS_WIN_H
+#define ESTEID_DIALOGS_WIN_H
 
 INT_PTR CALLBACK Pin2DialogProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 

--- a/firefox-win/plugin-class.c
+++ b/firefox-win/plugin-class.c
@@ -188,7 +188,7 @@ BOOL canUseCNG(char* id)
 	HCERTSTORE cert_store;
 	PCCERT_CONTEXT certContext = NULL;
 	NCRYPT_KEY_HANDLE hKey = NULL;
-	BOOL must_release_provider;
+	BOOL must_release_provider = FALSE;
 
 	if (isCNGInstalled())
 	{

--- a/firefox-win/plugin-class.c
+++ b/firefox-win/plugin-class.c
@@ -304,6 +304,7 @@ bool doSignCSP(PluginInstance *obj, BCRYPT_PKCS1_PADDING_INFO padInfo, char *inH
 		EstEID_log("_hash = %p, cryptoProvider = %p", _hash, cryptoProvider);
 		if (!CryptCreateHash(cryptoProvider, hashAlgorithm, 0, 0, &_hash)){
 			handleError("CryptCreateHash", obj);
+			free(hashBytes);
 			return false;
 		}
 		EstEID_log("CryptCreateHash() set hash object pointer to %p", _hash);

--- a/firefox-win/plugin-class.h
+++ b/firefox-win/plugin-class.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PLUGIN_CLASS_H__
-#define	__PLUGIN_CLASS_H__
+#ifndef ESTEID_PLUGIN_CLASS_H
+#define	ESTEID_PLUGIN_CLASS_H
 
 #define FAIL_IF_NOT_ALLOWED_SITE if(!isAllowedSite()) return false;
 

--- a/firefox-win/plugin-win.h
+++ b/firefox-win/plugin-win.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PLUGIN_WIN_H__
-#define	__PLUGIN_WIN_H__
+#ifndef ESTEID_PLUGIN_WIN_H
+#define	ESTEID_PLUGIN_WIN_H
 
 #define IDD_DIALOG1 8001
 #define IDC_PIN2 8002

--- a/firefox-win/plugin.c
+++ b/firefox-win/plugin.c
@@ -228,11 +228,13 @@ NPError NPP_SetWindow(NPP instanceData, NPWindow* window) {
 	if (window == NULL || instanceData == NULL) return NPERR_NO_ERROR;
 	PluginInstance* currentInstance = (PluginInstance*)(instanceData->pdata);
 
-	EstEID_log("window=%p, window->window=%p, currentInstance=%p, nativeWindowHandle=%p", window, window->window, currentInstance, currentInstance->nativeWindowHandle);
+	if (currentInstance) {
+		EstEID_log("window=%p, window->window=%p, currentInstance=%p, nativeWindowHandle=%p", window, window->window, currentInstance, currentInstance->nativeWindowHandle);
 
-	if (currentInstance && window->window && (currentInstance->nativeWindowHandle != window->window)) {
-		currentInstance->nativeWindowHandle = window->window;
-		EstEID_log("nativeWindowHandle=%p", currentInstance->nativeWindowHandle);
+		if (window->window && (currentInstance->nativeWindowHandle != window->window)) {
+			currentInstance->nativeWindowHandle = window->window;
+			EstEID_log("nativeWindowHandle=%p", currentInstance->nativeWindowHandle);
+		}
 	}
 	return NPERR_NO_ERROR;
 }

--- a/firefox-win/plugin.h
+++ b/firefox-win/plugin.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PLUGIN_H__
-#define	__PLUGIN_H__
+#ifndef ESTEID_PLUGIN_H
+#define	ESTEID_PLUGIN_H
 
 #include <windows.h>
 #define XP_WIN

--- a/firefox/cert-class.c
+++ b/firefox/cert-class.c
@@ -91,6 +91,9 @@ static NPClass _class = {
     (NPHasPropertyFunctionPtr) certHasProperty,
     (NPGetPropertyFunctionPtr) certGetProperty,
     (NPSetPropertyFunctionPtr) certSetProperty,
+    (NPRemovePropertyFunctionPtr)NULL,
+    (NPEnumerationFunctionPtr)NULL,
+    (NPConstructFunctionPtr)NULL
 };
 
 NPClass *certClass() {

--- a/firefox/cert-class.c
+++ b/firefox/cert-class.c
@@ -54,7 +54,7 @@ bool certSetProperty(CertInstance *obj, NPIdentifier name, const NPVariant *vari
 bool certHasProperty(NPClass *theClass, NPIdentifier name) {
 	FAIL_IF_NOT_ALLOWED_SITE
 	static char *certProperties[] = {"id", "cert", "CN", "issuerCN", "keyUsage", "validFrom", "validTo", "certSerialNumber", "certificateAsPEM", "certificateAsHex"};
-	for (int i = 0; i < sizeof(certProperties) / sizeof(char *); i++) {
+	for (unsigned i = 0u; i < sizeof(certProperties) / sizeof(char *); i++) {
 		if (isSameIdentifier(name, certProperties[i])) return true;
 	}
 	return false;

--- a/firefox/cert-class.h
+++ b/firefox/cert-class.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __CERT_CLASS_H__
-#define	__CERT_CLASS_H__
+#ifndef ESTEID_CERT_CLASS_H
+#define	ESTEID_CERT_CLASS_H
 
 #include "plugin.h"
 #include "esteid_map.h"

--- a/firefox/certselection-win.h
+++ b/firefox/certselection-win.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __CERTSELECTION_WIN_H__
-#define __CERTSELECTION_WIN_H__
+#ifndef ESTEID_CERTSELECTION_WIN_H
+#define ESTEID_CERTSELECTION_WIN_H
 
 #include <windows.h>
 #include <windowsx.h>

--- a/firefox/dialogs-gtk.c
+++ b/firefox/dialogs-gtk.c
@@ -255,7 +255,7 @@ static GtkTreeModel* createAndFillModel() {
 
   EstEID_Certs *certs = EstEID_loadCerts();
   EstEID_log("%i certificates found", certs->count);
-  for (int i = 0; i < certs->count; i++) {
+  for (unsigned i = 0u; i < certs->count; i++) {
     EstEID_Map cert = certs->certs[i];
     if (!EstEID_mapGet(cert, "usageNonRepudiation")) continue;
 

--- a/firefox/dialogs-win.h
+++ b/firefox/dialogs-win.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __DIALOGS_WIN_H__
-#define __DIALOGS_WIN_H__
+#ifndef ESTEID_DIALOGS_WIN_H
+#define ESTEID_DIALOGS_WIN_H
 
 INT_PTR CALLBACK Pin2DialogProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 

--- a/firefox/plugin-class.c
+++ b/firefox/plugin-class.c
@@ -140,7 +140,7 @@ bool doSign(PluginInstance *obj, NPVariant *args, unsigned argCount, NPVariant *
 
 	void* wnd = getNativeWindowHandle(obj);
 
-	EstEID_PINPromptData pinPromptData = {promptForPIN, showAlert, wnd};
+	EstEID_PINPromptData pinPromptData = {promptForPIN, showAlert, wnd, NULL};
 	NPUTF8* certId = createStringFromNPVariant(&args[0]);
 	NPUTF8* hash = createStringFromNPVariant(&args[1]);
 	char *signature = NULL;
@@ -305,6 +305,9 @@ static NPClass _class = {
 	(NPHasPropertyFunctionPtr)pluginHasProperty,
 	(NPGetPropertyFunctionPtr)pluginGetProperty,
 	(NPSetPropertyFunctionPtr)pluginSetProperty,
+	(NPRemovePropertyFunctionPtr)NULL,
+	(NPEnumerationFunctionPtr)NULL,
+	(NPConstructFunctionPtr)NULL
 };
 
 NPClass *pluginClass() {

--- a/firefox/plugin-class.c
+++ b/firefox/plugin-class.c
@@ -227,7 +227,7 @@ bool doGetCertificates(PluginInstance *obj, NPVariant *result) {
 	NPVariant array;
 	browserFunctions->invoke(obj->npp, windowObject, browserFunctions->getstringidentifier("Array"), NULL, 0, &array);
 	EstEID_Certs *certs = EstEID_loadCerts();
-	for (int i = 0; i < certs->count; i++) {
+	for (unsigned i = 0u; i < certs->count; i++) {
 		EstEID_Map cert = certs->certs[i];
 		if (!EstEID_mapGet(cert, "usageNonRepudiation")) continue;
 		CertInstance *certInstance = (CertInstance *)browserFunctions->createobject(obj->npp, certClass());

--- a/firefox/plugin-class.h
+++ b/firefox/plugin-class.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PLUGIN_CLASS_H__
-#define	__PLUGIN_CLASS_H__
+#ifndef ESTEID_PLUGIN_CLASS_H
+#define	ESTEID_PLUGIN_CLASS_H
 
 #define FAIL_IF_NOT_ALLOWED_SITE if(!isAllowedSite()) return false;
 

--- a/firefox/plugin-win.h
+++ b/firefox/plugin-win.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PLUGIN_WIN_H__
-#define	__PLUGIN_WIN_H__
+#ifndef ESTEID_PLUGIN_WIN_H
+#define	ESTEID_PLUGIN_WIN_H
 
 #define IDD_DIALOG1 8001
 #define IDC_PIN2 8002

--- a/firefox/plugin.c
+++ b/firefox/plugin.c
@@ -258,13 +258,12 @@ NPError NPP_SetWindow(NPP instanceData, NPWindow* window) {
 	LOG_LOCATION;
 	if (window == NULL || instanceData == NULL) return NPERR_NO_ERROR;
 	PluginInstance* currentInstance = (PluginInstance*)(instanceData->pdata);
-
-	EstEID_log("window=%p, window->window=%p, currentInstance=%p, nativeWindowHandle=%p", window, window->window, currentInstance, currentInstance->nativeWindowHandle);
-
-	if (currentInstance && window->window && (currentInstance->nativeWindowHandle != window->window)) {
-		currentInstance->nativeWindowHandle = window->window;
+	if (currentInstance) {
+		EstEID_log("window=%p, window->window=%p, currentInstance=%p, nativeWindowHandle=%p", window, window->window, currentInstance, currentInstance->nativeWindowHandle);
+		if (window->window && (currentInstance->nativeWindowHandle != window->window))
+			currentInstance->nativeWindowHandle = window->window;
+		EstEID_log("nativeWindowHandle=%p", currentInstance->nativeWindowHandle);
 	}
-	EstEID_log("nativeWindowHandle=%p", currentInstance->nativeWindowHandle);
 
 	return NPERR_NO_ERROR;
 }

--- a/firefox/plugin.c
+++ b/firefox/plugin.c
@@ -263,7 +263,6 @@ NPError NPP_SetWindow(NPP instanceData, NPWindow* window) {
 
 	if (currentInstance && window->window && (currentInstance->nativeWindowHandle != window->window)) {
 		currentInstance->nativeWindowHandle = window->window;
-		EstEID_log("nativeWindowHandle=%p", currentInstance->nativeWindowHandle);
 	}
 	EstEID_log("nativeWindowHandle=%p", currentInstance->nativeWindowHandle);
 

--- a/firefox/plugin.h
+++ b/firefox/plugin.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef __PLUGIN_H__
-#define	__PLUGIN_H__
+#ifndef ESTEID_PLUGIN_H
+#define	ESTEID_PLUGIN_H
 
 #ifdef __APPLE__
 #define XP_MACOSX


### PR DESCRIPTION
After catching a cold on vacation, I happened to look at this C code, and I found it to have rather poor quality, so I ended up spending a few hours coding these simple fixes. It looks like there's still much to improve, especially with respect to `malloc()` returning `NULL` when memory runs out, and also with integer promotions and signed-unsigned conversions overflowing and underflowing. A lot of performance improvements are possible as well.

Anyway, these are the commits I ended up with today. It seemed to compile on my Linux (in case MS hasn't fixed it, VC might complain about a missing `<stdint.h>`), but I didn't test any of the changes at runtime. You're welcome to merge, rebase or cherry-pick any of these.

PS: I suggest you use some static analysis tools like [cppcheck](http://cppcheck.sourceforge.net/), [PVS Studio](http://www.viva64.com/en/pvs-studio/) or something. And do take a look at the [CERT coding standards](https://www.securecoding.cert.org/confluence/display/seccode/SEI+CERT+Coding+Standards).
